### PR TITLE
Update compare errors using errors.ls() instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sean DuBois](https://github.com/Sean-Der) - *Original Author*
 * [Michiel De Backker](https://github.com/backkem) - *Original Author*
 * [Atsushi Watanabe](https://github.com/at-wat) - *Original Author*
+* [ZHENK](https://github.com/scorpionknifes)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/conn.go
+++ b/conn.go
@@ -13,11 +13,15 @@ import (
 	"github.com/pion/transport/packetio"
 )
 
-const receiveMTU = 8192
-const defaultListenBacklog = 128 // same as Linux default
+const (
+	receiveMTU           = 8192
+	defaultListenBacklog = 128 // same as Linux default
+)
 
-var errClosedListener = errors.New("udp: listener closed")
-var errListenQueueExceeded = errors.New("udp: listen queue exceeded")
+var (
+	errClosedListener      = errors.New("udp: listener closed")
+	errListenQueueExceeded = errors.New("udp: listen queue exceeded")
+)
 
 // listener augments a connection-oriented Listener over a UDP PacketConn
 type listener struct {

--- a/conn_test.go
+++ b/conn_test.go
@@ -4,6 +4,7 @@ package udp
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -14,7 +15,7 @@ import (
 )
 
 // Note: doesn't work since closing isn't propagated to the other side
-//func TestNetTest(t *testing.T) {
+// func TestNetTest(t *testing.T) {
 //	lim := test.TimeOut(time.Minute*1 + time.Second*10)
 //	defer lim.Stop()
 //
@@ -210,7 +211,7 @@ func TestListenerAcceptFilter(t *testing.T) {
 
 				conn, aerr := listener.Accept()
 				if aerr != nil {
-					if aerr != errClosedListener {
+					if !errors.Is(aerr, errClosedListener) {
 						t.Error(aerr)
 					}
 					return
@@ -296,7 +297,7 @@ func TestListenerConcurrent(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if conn, aerr := listener.Accept(); aerr != errClosedListener {
+		if conn, aerr := listener.Accept(); !errors.Is(aerr, errClosedListener) {
 			t.Errorf("Connection exceeding backlog limit must be discarded: %v", aerr)
 			if aerr == nil {
 				_ = conn.Close()

--- a/conn_test.go
+++ b/conn_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/pion/transport/test"
 )
 
+var errHandshakeFailed = errors.New("handshake failed")
+
 // Note: doesn't work since closing isn't propagated to the other side
 // func TestNetTest(t *testing.T) {
 //	lim := test.TimeOut(time.Minute*1 + time.Second*10)
@@ -32,8 +34,6 @@ import (
 //		return
 //	})
 //}
-
-var errHandshakeFailed = errors.New("handshake failed")
 
 func TestStressDuplex(t *testing.T) {
 	// Limit runtime in case of deadlocks


### PR DESCRIPTION
#### Description

Fixes to:
_err113: do not compare errors directly, use errors.Is() instead
commentFormatting: put a space between `//` and comment text (gocritic)_

No idea how to fix: 
_File is not `gofmt`-ed with `-s` (gofmt)_

Not sure about changing this into static errors - remove err in conn_test.go
_err113: do not define dynamic errors, use wrapped static errors instead: "fmt.Errorf(\"failed to listen: %v\", err)" (goerr113)_