### PR TITLE
Export error variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Michiel De Backker](https://github.com/backkem) - *Original Author*
 * [Atsushi Watanabe](https://github.com/at-wat) - *Original Author*
 * [ZHENK](https://github.com/scorpionknifes)
+* [Daniel Beseda](https://github.com/besedad)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/conn.go
+++ b/conn.go
@@ -19,8 +19,8 @@ const (
 )
 
 var (
-	errClosedListener      = errors.New("udp: listener closed")
-	errListenQueueExceeded = errors.New("udp: listen queue exceeded")
+	ErrClosedListener      = errors.New("udp: listener closed")       //nolint
+	ErrListenQueueExceeded = errors.New("udp: listen queue exceeded") //nolint
 )
 
 // listener augments a connection-oriented Listener over a UDP PacketConn
@@ -50,7 +50,7 @@ func (l *listener) Accept() (net.Conn, error) {
 		return c, nil
 
 	case <-l.doneCh:
-		return nil, errClosedListener
+		return nil, ErrClosedListener
 	}
 }
 
@@ -189,7 +189,7 @@ func (l *listener) getConn(raddr net.Addr, buf []byte) (*Conn, bool, error) {
 	conn, ok := l.conns[raddr.String()]
 	if !ok {
 		if !l.accepting.Load().(bool) {
-			return nil, false, errClosedListener
+			return nil, false, ErrClosedListener
 		}
 		if l.acceptFilter != nil {
 			if !l.acceptFilter(buf) {
@@ -201,7 +201,7 @@ func (l *listener) getConn(raddr net.Addr, buf []byte) (*Conn, bool, error) {
 		case l.acceptCh <- conn:
 			l.conns[raddr.String()] = conn
 		default:
-			return nil, false, errListenQueueExceeded
+			return nil, false, ErrListenQueueExceeded
 		}
 	}
 	return conn, true, nil

--- a/conn_test.go
+++ b/conn_test.go
@@ -213,7 +213,7 @@ func TestListenerAcceptFilter(t *testing.T) {
 
 				conn, aerr := listener.Accept()
 				if aerr != nil {
-					if !errors.Is(aerr, errClosedListener) {
+					if !errors.Is(aerr, ErrClosedListener) {
 						t.Error(aerr)
 					}
 					return
@@ -299,7 +299,7 @@ func TestListenerConcurrent(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if conn, aerr := listener.Accept(); !errors.Is(aerr, errClosedListener) {
+		if conn, aerr := listener.Accept(); !errors.Is(aerr, ErrClosedListener) {
 			t.Errorf("Connection exceeding backlog limit must be discarded: %v", aerr)
 			if aerr == nil {
 				_ = conn.Close()


### PR DESCRIPTION
#### Description

Export error variables out of the package. Unlike what's stated in #37, PR exports all (_two_) error variables. We don't have a use for the other variable but someone else might. If that's a problem, I'll revert back to what's in line with the ticket.

#### Reference issue
Fixes #37 
