### PR TITLE
Refactoring to support `net.PacketConn` and dialling

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -217,6 +217,18 @@ func (l *listener) getConn(raddr net.Addr, buf []byte) (*Conn, bool, error) {
 	return conn, true, nil
 }
 
+func (l *listener) Dial(raddr net.Addr) (net.Conn, error) {
+	l.connLock.Lock()
+	defer l.connLock.Unlock()
+	conn, ok := l.conns[raddr.String()]
+	if ok {
+		return conn, nil
+	}
+	conn = l.newConn(raddr)
+	l.conns[raddr.String()] = conn
+	return conn, nil
+}
+
 // Conn augments a connection-oriented connection over a UDP PacketConn
 type Conn struct {
 	listener *listener

--- a/conn.go
+++ b/conn.go
@@ -24,8 +24,8 @@ var (
 	ErrListenQueueExceeded = errors.New("udp: listen queue exceeded")
 )
 
-// listener augments a connection-oriented Listener over a UDP PacketConn
-type listener struct {
+// Endpoint augments connection-oriented Listeners and Conns over a UDP PacketConn
+type Endpoint struct {
 	pConn net.PacketConn
 
 	accepting      atomic.Value // bool
@@ -44,7 +44,7 @@ type listener struct {
 }
 
 // Accept waits for and returns the next connection to the listener.
-func (l *listener) Accept() (net.Conn, error) {
+func (l *Endpoint) Accept() (net.Conn, error) {
 	select {
 	case c := <-l.acceptCh:
 		l.connWG.Add(1)
@@ -57,7 +57,7 @@ func (l *listener) Accept() (net.Conn, error) {
 
 // Close closes the listener.
 // Any blocked Accept operations will be unblocked and return errors.
-func (l *listener) Close() error {
+func (l *Endpoint) Close() error {
 	var err error
 	l.doneOnce.Do(func() {
 		l.accepting.Store(false)
@@ -96,7 +96,7 @@ func (l *listener) Close() error {
 }
 
 // Addr returns the listener's network address.
-func (l *listener) Addr() net.Addr {
+func (l *Endpoint) Addr() net.Addr {
 	return l.pConn.LocalAddr()
 }
 
@@ -116,7 +116,7 @@ type ListenConfig struct {
 }
 
 // Listen creates a new listener based on the ListenConfig.
-func (lc *ListenConfig) Listen(network string, laddr *net.UDPAddr) (net.Listener, error) {
+func (lc *ListenConfig) Listen(network string, laddr *net.UDPAddr) (*Endpoint, error) {
 	if lc.Backlog == 0 {
 		lc.Backlog = defaultListenBacklog
 	}
@@ -130,8 +130,8 @@ func (lc *ListenConfig) Listen(network string, laddr *net.UDPAddr) (net.Listener
 }
 
 // ListenOn creates a new listener based on the existing ListenConfig with an existing PacketConn.
-func (lc *ListenConfig) ListenOn(pConn net.PacketConn) (net.Listener, error) {
-	l := &listener{
+func (lc *ListenConfig) ListenOn(pConn net.PacketConn) (*Endpoint, error) {
+	l := &Endpoint{
 		pConn:        pConn,
 		acceptCh:     make(chan *Conn, lc.Backlog),
 		conns:        make(map[string]*Conn),
@@ -170,7 +170,7 @@ func Listen(network string, laddr *net.UDPAddr) (net.Listener, error) {
 // 1. Dispatching incoming packets to the correct Conn.
 //    It can therefore not be ended until all Conns are closed.
 // 2. Creating a new Conn when receiving from a new remote.
-func (l *listener) readLoop() {
+func (l *Endpoint) readLoop() {
 	defer l.readWG.Done()
 
 	for {
@@ -193,7 +193,7 @@ func (l *listener) readLoop() {
 	}
 }
 
-func (l *listener) getConn(raddr net.Addr, buf []byte) (*Conn, bool, error) {
+func (l *Endpoint) getConn(raddr net.Addr, buf []byte) (*Conn, bool, error) {
 	l.connLock.Lock()
 	defer l.connLock.Unlock()
 	conn, ok := l.conns[raddr.String()]
@@ -217,7 +217,7 @@ func (l *listener) getConn(raddr net.Addr, buf []byte) (*Conn, bool, error) {
 	return conn, true, nil
 }
 
-func (l *listener) Dial(raddr net.Addr) (net.Conn, error) {
+func (l *Endpoint) Dial(raddr net.Addr) (net.Conn, error) {
 	l.connLock.Lock()
 	defer l.connLock.Unlock()
 	conn, ok := l.conns[raddr.String()]
@@ -231,7 +231,7 @@ func (l *listener) Dial(raddr net.Addr) (net.Conn, error) {
 
 // Conn augments a connection-oriented connection over a UDP PacketConn
 type Conn struct {
-	listener *listener
+	listener *Endpoint
 
 	rAddr net.Addr
 
@@ -243,7 +243,7 @@ type Conn struct {
 	writeDeadline *deadline.Deadline
 }
 
-func (l *listener) newConn(rAddr net.Addr) *Conn {
+func (l *Endpoint) newConn(rAddr net.Addr) *Conn {
 	return &Conn{
 		listener:      l,
 		rAddr:         rAddr,

--- a/conn.go
+++ b/conn.go
@@ -162,8 +162,13 @@ func (lc *ListenConfig) ListenOn(pConn net.PacketConn) (*Endpoint, error) {
 }
 
 // Listen creates a new listener using default ListenConfig.
-func Listen(network string, laddr *net.UDPAddr) (net.Listener, error) {
+func Listen(network string, laddr *net.UDPAddr) (*Endpoint, error) {
 	return (&ListenConfig{}).Listen(network, laddr)
+}
+
+// ListenOn creates a new listener using default ListenConfig on an existing PacketConn.
+func ListenOn(pConn net.PacketConn) (*Endpoint, error) {
+	return (&ListenConfig{}).ListenOn(pConn)
 }
 
 // readLoop has to tasks:
@@ -217,6 +222,7 @@ func (l *Endpoint) getConn(raddr net.Addr, buf []byte) (*Conn, bool, error) {
 	return conn, true, nil
 }
 
+// Dial creates a new connection-oriented connection over the listening PacketConn
 func (l *Endpoint) Dial(raddr net.Addr) (net.Conn, error) {
 	l.connLock.Lock()
 	defer l.connLock.Unlock()

--- a/conn.go
+++ b/conn.go
@@ -26,7 +26,7 @@ var (
 
 // listener augments a connection-oriented Listener over a UDP PacketConn
 type listener struct {
-	pConn *net.UDPConn
+	pConn net.PacketConn
 
 	accepting      atomic.Value // bool
 	acceptCh       chan *Conn
@@ -126,8 +126,13 @@ func (lc *ListenConfig) Listen(network string, laddr *net.UDPAddr) (net.Listener
 		return nil, err
 	}
 
+	return lc.ListenOn(conn)
+}
+
+// ListenOn creates a new listener based on the existing ListenConfig with an existing PacketConn.
+func (lc *ListenConfig) ListenOn(pConn net.PacketConn) (net.Listener, error) {
 	l := &listener{
-		pConn:        conn,
+		pConn:        pConn,
 		acceptCh:     make(chan *Conn, lc.Backlog),
 		conns:        make(map[string]*Conn),
 		doneCh:       make(chan struct{}),

--- a/conn_test.go
+++ b/conn_test.go
@@ -397,7 +397,7 @@ func TestConnClose(t *testing.T) {
 			t.Fatal(errPipe)
 		}
 		// Close l.pConn to inject error.
-		if err := l.(*listener).pConn.Close(); err != nil { //nolint:forcetypeassert
+		if err := l.(*Endpoint).pConn.Close(); err != nil { //nolint:forcetypeassert
 			t.Error(err)
 		}
 
@@ -421,7 +421,7 @@ func TestConnClose(t *testing.T) {
 			t.Fatal(errPipe)
 		}
 		// Close l.pConn to inject error.
-		if err := l.(*listener).pConn.Close(); err != nil { //nolint:forcetypeassert
+		if err := l.(*Endpoint).pConn.Close(); err != nil { //nolint:forcetypeassert
 			t.Error(err)
 		}
 


### PR DESCRIPTION
This makes a few changes:

* Adds a new `ListenOn` function which takes an existing `net.PacketConn` as an argument rather than a UDP endpoint address
* Adds a new `Dial` function to the `Endpoint` which allows creating a new outbound connection on the existing `net.PacketConn` 
* Changes `listener` to an exported `Endpoint` type, which is now returned by `Listen` and `ListenOn` (which still conforms to `net.Listener` so the return type changing won't break existing code)
* Adds a unit test for the above

The goal being that the package now can operate pretty much agnostically on anything that conforms to the `net.PacketConn` interface, like Yggdrasil and Pinecone overlay networks, QUIC connections etc.