### PR TITLE
Fix `Read` cancellation on `Close`

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -274,7 +274,9 @@ func (c *Conn) Close() error {
 			err = nil
 		}
 
-		c.buffer.Close()
+		if errBuf := c.buffer.Close(); errBuf != nil && err == nil {
+			err = errBuf
+		}
 	})
 
 	return err

--- a/conn.go
+++ b/conn.go
@@ -273,6 +273,8 @@ func (c *Conn) Close() error {
 		} else {
 			err = nil
 		}
+
+		c.buffer.Close()
 	})
 
 	return err


### PR DESCRIPTION
#### Description

Since we were not closing the transport buffer, `Read`s were hanging indefinitely.

#### Reference issue

Not reported.
