### PR TITLE
Fix data race on listener.connWG

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -5,5 +5,6 @@
 # see `.github/generate-authors.sh` for the scripting
 Atsushi Watanabe <atsushi.w@ieee.org>
 Daniel Beseda <daniel.beseda@energomonitor.cz>
+Jozef Kralik <jojo.lwin@gmail.com>
 Michiel De Backker <mail@backkem.me>
 ZHENK <chengzhenyang@gmail.com>

--- a/pkg/sync/waitgroup.go
+++ b/pkg/sync/waitgroup.go
@@ -1,0 +1,68 @@
+// Package sync extends basic synchronization primitives.
+package sync
+
+import (
+	"sync"
+)
+
+// A WaitGroup waits for a collection of goroutines to finish.
+// The main goroutine calls Add to set the number of
+// goroutines to wait for. Then each of the goroutines
+// runs and calls Done when finished. At the same time,
+// Wait can be used to block until all goroutines have finished.
+//
+// WaitGroups in the sync package do not allow adding or
+// subtracting from the counter while another goroutine is
+// waiting, while this one does.
+//
+// A WaitGroup must not be copied after first use.
+//
+// In the terminology of the Go memory model, a call to Done
+type WaitGroup struct {
+	c     int64
+	mutex sync.Mutex
+	cond  *sync.Cond
+}
+
+// NewWaitGroup creates a new WaitGroup.
+func NewWaitGroup() *WaitGroup {
+	wg := &WaitGroup{}
+	wg.cond = sync.NewCond(&wg.mutex)
+	return wg
+}
+
+// Add adds delta, which may be negative, to the WaitGroup counter.
+// If the counter becomes zero, all goroutines blocked on Wait are released.
+// If the counter goes negative, Add panics.
+func (wg *WaitGroup) Add(delta int) {
+	wg.mutex.Lock()
+	defer wg.mutex.Unlock()
+	wg.c += int64(delta)
+	if wg.c < 0 {
+		panic("udp: negative WaitGroup counter") // nolint
+	}
+	wg.cond.Signal()
+}
+
+// Done decrements the WaitGroup counter by one.
+func (wg *WaitGroup) Done() {
+	wg.Add(-1)
+}
+
+// Wait blocks until the WaitGroup counter is zero.
+func (wg *WaitGroup) Wait() {
+	wg.mutex.Lock()
+	defer wg.mutex.Unlock()
+	for {
+		c := wg.c
+		switch {
+		case c == 0:
+			// wake another goroutine if there is one
+			wg.cond.Signal()
+			return
+		case c < 0:
+			panic("udp: negative WaitGroup counter") // nolint
+		}
+		wg.cond.Wait()
+	}
+}

--- a/pkg/sync/waitgroup_test.go
+++ b/pkg/sync/waitgroup_test.go
@@ -1,0 +1,46 @@
+//go:build !js
+// +build !js
+
+package sync_test
+
+import (
+	"testing"
+
+	"github.com/pion/udp/pkg/sync"
+)
+
+func testWaitGroup(t *testing.T, wg1 *sync.WaitGroup, wg2 *sync.WaitGroup) {
+	n := 16
+	wg1.Add(n)
+	wg2.Add(n)
+	exited := make(chan bool, n)
+	for i := 0; i != n; i++ {
+		go func() {
+			wg1.Done()
+			wg2.Wait()
+			exited <- true
+		}()
+	}
+	wg1.Wait()
+	for i := 0; i != n; i++ {
+		select {
+		case <-exited:
+			t.Fatal("WaitGroup released group too soon")
+		default:
+		}
+		wg2.Done()
+	}
+	for i := 0; i != n; i++ {
+		<-exited // Will block if barrier fails to unlock someone.
+	}
+}
+
+func TestWaitGroup(t *testing.T) {
+	wg1 := sync.NewWaitGroup()
+	wg2 := sync.NewWaitGroup()
+
+	// Run the same test a few times to ensure barrier is in a proper state.
+	for i := 0; i != 8; i++ {
+		testWaitGroup(t, wg1, wg2)
+	}
+}


### PR DESCRIPTION
#### Description
Function waitGroup.Add cannot be called when another goroutine calls waitGroup.Wait as is mentioned in
note: https://pkg.go.dev/sync#WaitGroup.Add

#### Reference issue
Fixes #74
