### PR TITLE
fix: Conn.Close does not unblock Reads

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -259,6 +259,9 @@ func (c *Conn) Close() error {
 	c.doneOnce.Do(func() {
 		c.listener.connWG.Done()
 		close(c.doneCh)
+		if bufErr := c.buffer.Close(); err != nil {
+			err = bufErr
+		}
 		c.listener.connLock.Lock()
 		delete(c.listener.conns, c.rAddr.String())
 		nConns := len(c.listener.conns)

--- a/conn_test.go
+++ b/conn_test.go
@@ -253,64 +253,27 @@ func TestConnReadDuringClose(t *testing.T) {
 	report := test.CheckRoutines(t)
 	defer report()
 
-	network, addr := getConfig()
-	listener, err := (&ListenConfig{
-		Backlog: 2,
-	}).Listen(network, addr)
+	listener, lConn, _, err := pipe()
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	msg := "foo"
-
-	conn, derr := net.DialUDP(network, nil, listener.Addr().(*net.UDPAddr))
-	if derr != nil {
-		t.Error(derr)
-	}
-	if _, werr := conn.Write([]byte(msg)); werr != nil {
-		t.Error(werr)
-	}
-
-	lConn, err := listener.Accept()
-	if err != nil {
-		t.Error(err)
+		t.Fatalf("expected err to be nil but got %v", err)
 	}
 	defer func() { _ = listener.Close() }()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-
 	errC := make(chan error, 1)
 	go func() {
-		defer wg.Done()
-		buf := make([]byte, len(msg))
-		if _, err := lConn.Read(buf); err != nil {
-			errC <- err
-			return
-		}
-		if string(buf) != msg {
-			errC <- fmt.Errorf("expected %s to be %s", string(buf), msg) // nolint
-			return
-		}
+		buf := make([]byte, 1024)
+		// This read will block because we don't write on the other side.
+		// Calling Close must unblock the call.
 		_, err := lConn.Read(buf)
-		expectErr := io.EOF
-		if !errors.Is(err, expectErr) {
-			errC <- fmt.Errorf("expected err to be %s but got %w", expectErr, err)
-			return
-		}
+		errC <- err
 	}()
 
 	if err := lConn.Close(); err != nil {
 		t.Errorf("expected err to be nil but got %v", err)
 	}
 
-	wg.Wait()
-
-	close(errC)
-	for err := range errC {
-		if err != nil {
-			t.Errorf("err from errC: %v", err)
-		}
+	if !errors.Is(<-errC, io.EOF) {
+		t.Errorf("err from errC: %v", err)
 	}
 }
 


### PR DESCRIPTION
#### Description

The buffer on `Conn` is not closed when `(*Conn).Close()` is called.
This can deadlock another goroutine that is waiting on `(*Conn).Read()`. The expectation is  when `Close()` is called, the `Read` call is unblocked and an error is returned.

