### PR TITLE
Fix Read cancellation on Close

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,5 +6,7 @@
 Atsushi Watanabe <atsushi.w@ieee.org>
 Daniel Beseda <daniel.beseda@energomonitor.cz>
 Jozef Kralik <jojo.lwin@gmail.com>
+Mathias Fredriksson <mafredri@gmail.com>
 Michiel De Backker <mail@backkem.me>
+sterling.deng <sterling.deng@getcruise.com>
 ZHENK <chengzhenyang@gmail.com>

--- a/conn.go
+++ b/conn.go
@@ -273,6 +273,10 @@ func (c *Conn) Close() error {
 		} else {
 			err = nil
 		}
+
+		if errBuf := c.buffer.Close(); errBuf != nil && err == nil {
+			err = errBuf
+		}
 	})
 
 	return err


### PR DESCRIPTION
Since we were not closing the transport buffer, `Read`s were hanging indefinitely.

Co-authored-by: @mafredri and @sterlingdeng

#### Reference issue
Squash https://github.com/pion/udp/pull/73 and https://github.com/pion/udp/pull/80

Close https://github.com/pion/udp/pull/73
Close https://github.com/pion/udp/pull/80